### PR TITLE
change routes for update

### DIFF
--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -33,8 +33,7 @@ $(document).on('turbolinks:load', function(){
         })
 
       }else{
-        let update_schedule = $(this).data('schedule-id');
-        let update_url = '/users/' + user_id + '/schedules/' + update_schedule;
+        let update_url = '/users/' + user_id + '/schedules/';
         $(this).prop('id', 'leave');
         $(this).removeClass('employee__box__list__name_select');
         

--- a/app/assets/stylesheets/_users_list.scss
+++ b/app/assets/stylesheets/_users_list.scss
@@ -52,13 +52,28 @@ h2{
 }
 
 
+.upper_area{
+  margin: 0px auto 15px;
+  top:100px;
+  width: 100%;
+  text-align: center;
+
+  .employee_name{
+    padding: 10px;
+    font-size: 130%;
+    font-weight: bold;
+    letter-spacing: 1.5px;
+  }
+
+}
+
 
 .table__box{
-  top:100px;
+  top:90px;
   margin: auto;
   position: relative;
   overflow: scroll;
-  width: 40%;
+  width: 50%;
   max-height: 75%;
 }
 
@@ -66,24 +81,53 @@ h2{
   margin: auto;
   width: 100%;
   border: solid 1px #333;
-}
 
-.list_table__style th{
-  width: 50%;
-  background-color: $main_color;
-  color:#fff;
-  font-weight: bold;
-  border: solid 1px #333;
-  border-collapse: collapse;
-  padding: 10px;
-}
 
-.list_table__style td{
-  margin:0 auto;
-  padding: 12px;
-  text-align: center;
-  font-size: 110%;
-  background-color: #fff;
-  border: solid 1px #333;
-  border-collapse: collapse;
-}
+      & th{
+        width: 15%;
+        background-color: $main_color;
+        color:#fff;
+        font-weight: bold;
+        border: solid 1px #333;
+        border-collapse: collapse;
+        padding: 10px;
+      }
+
+      .change{
+        width: 7%;
+      }
+
+
+      & td{
+        margin:0 auto;
+        padding: 12px 5px;
+        text-align: center;
+        font-size: 110%;
+        background-color: #fff;
+        border: solid 1px #333;
+        border-collapse: collapse;
+
+        & :hover{
+            color:$main_color;
+           }
+
+        .date{
+          font-size: 80%;
+        }
+
+        .input_box{
+          width: 80%;
+          height: 35px;
+          padding: 0 5px;
+          font-size: 1em;
+        }
+
+        .input_btn{
+          width: 80%;
+          height: 30px;
+          border: none;
+          font-size: 1em;
+        }
+
+      }
+  }

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -2,6 +2,10 @@ class SchedulesController < ApplicationController
 
   def index
     @schedules = Schedule.where(schedule_params)
+    @schedules.each do |schedule|
+      @sch = schedule.user_id
+    end
+    @user = User.find(@sch)
   end
 
   def new
@@ -17,22 +21,43 @@ class SchedulesController < ApplicationController
     end
   end
 
-
-  def update
+  def edit
     user = User.find(schedule_params[:user_id])
     @schedule = Schedule.find(user.schedules.ids.sort.last)
-    @schedule.update!(out: params[:sch])
+    @schedule.update(out: params[:sch])
     respond_to do |format|
       format.html {redirect_to ("/")}
       format.json
     end
   end
 
+  def show
+    @user = User.find(params[:user_id])
+    @schedule = Schedule.find(params[:id])
+  end
 
+
+  def update
+    @user = User.find(params[:user_id])
+    @schedule = Schedule.find(params[:id])
+    @schedule.update!(update_params)
+    redirect_to action: 'index'
+  end
+
+  def destroy
+    # user = User.find(params[:user_id])
+    schedule = Schedule.find(params[:id])
+    schedule.destroy
+    redirect_to action: 'index'
+  end
   
   private
   def schedule_params
     params.permit(:in, :out, :user_id)
+  end
+
+  def update_params
+    params.require(:schedule).permit(:in, :out, :user_id)
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   
-  has_many :schedules
+  has_many :schedules, dependent: :destroy
 
   validates :name, :email, :password,  {presence: true, uniqueness: true}
   

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,13 +1,28 @@
 <%= render partial: "users/header" %>
 
 <div class="table__box">
+
+<div class="upper_area">
+<p class="employee_name">
+<%= @user.name %> さんの勤怠状況
+</p>
+</div>
+
+
 <table class="list_table__style">
 
+<th>日付</th>
 <th>出勤</th>
 <th>退勤</th>
-</tr>
-<% @schedules.each do |schedule| %>
+<th class="change">修正</th>
+<th class="change">削除</th>
+
 <tr>
+<% @schedules.each do |schedule| %>
+<td>
+  <p class="date"><%= schedule.created_at.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[schedule.created_at.wday]})" ) %></p>
+</td>
+
 <td><% if schedule.in.present? %>
     <%= schedule.in.strftime('%H:%M') %>
     <% else %>
@@ -22,6 +37,13 @@
     <% end %>
 </td>
 
+<td>
+<%= link_to "修正", "/users/#{schedule.user_id}/schedules/#{schedule.id}" %>
+</td>
+
+<td>
+  <%= link_to "削除", "/users/#{schedule.user_id}/schedules/#{schedule.id}", method: :delete, type: "submit", class: 'input_btn', data:{ confirm: "削除しますか？", commit: "はい", cancel: "いいえ"} %>
+</td>
 </tr>
 <% end %>
 </table>
@@ -35,9 +57,9 @@
           <i class="fas fa-user-plus"></i><span class="setting_box__button-text">登録</span>
       </div>
       </a>
-      <a href="/">
+      <a href="/users/show">
       <div class="setting_box__button">
-          <i class="fas fa-home"></i><span class="setting_box__button-text">戻る</span>
+           <i class="fas fa-user-cog"></i><span class="setting_box__button-text">戻る</span>
       </div>
       </a>
     </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,0 +1,54 @@
+<%= render partial: "users/header" %>
+
+<div class="table__box">
+
+<div class="upper_area">
+<p class="employee_name">
+<%= @user.name %> さんの<%= @schedule.created_at.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[@schedule.created_at.wday]})" ) %> の退勤時間を修正
+</p>
+</div>
+
+<%= form_for [@schedule], url: user_schedule_path do |f| %>
+<table class="list_table__style">
+
+<th>出勤</th>
+<th>退勤</th>
+<th class="change">修正</th>
+
+<tr>
+<td>
+  <%= f.time_field :in, class: 'input_box' %>
+</td>
+
+<td>
+  <%= f.time_field :out, class: 'input_box' %>
+</td>
+
+<td>
+  <%= f.submit :修正, type: "submit", class: 'input_btn', data:{ confirm: "変更しますか？", commit: "はい", cancel: "いいえ"} do %>
+</td>
+
+</tr>
+<% end %>
+</table>
+</div>
+
+
+
+
+
+<footer>
+    <div class="setting_box">
+      <a href=" /users/<%= @schedule.user_id %>/schedules">
+      <div class="setting_box__button" id="registration">
+           <i class="fas fa-user-cog"></i><span class="setting_box__button-text">戻る</span>
+      </div>
+      </a>
+      <a href="/">
+      <div class="setting_box__button">
+          <i class="fas fa-home"></i><span class="setting_box__button-text">TOP</span>
+      </div>
+      </a>
+    </div>
+  <% end %>
+  </footer>

--- a/app/views/users/_employee.html.erb
+++ b/app/views/users/_employee.html.erb
@@ -1,5 +1,5 @@
 <% @users.each do |user| %>
 <ul class="employee__box__list">
-      <li class="employee__box__list__name", id="leave", value="<%=user.id%>" data-user-id="<%=user.id%>",  data-schedule-id="1"><%= user.name %></li>
+      <li class="employee__box__list__name", id="leave", value="<%=user.id%>" data-user-id="<%=user.id%>"><%= user.name %></li>
 </ul>
 <% end %>

--- a/app/views/users/_header.html.erb
+++ b/app/views/users/_header.html.erb
@@ -1,3 +1,3 @@
 <header>
-  <h1 class="title">きんたいあぷり</h1><span class="header__realtime" id="datetime"></span>
+  <a href="/"><h1 class="title">きんたいあぷり</h1></a><span class="header__realtime" id="datetime"></span>
 </header>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,10 @@ module AttendanceManagement
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.available_locales = [:en, :ja]
+    config.time_zone = "Tokyo"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,26 @@
+ja:
+  date:
+    formats:
+      default: "%Y/%m/%d"
+      short: "%m/%d"
+      long:  "%Y年%m月%d日(%a)"
+
+    day_names: [日曜日, 月曜日, 火曜日, 水曜日, 木曜日, 金曜日, 土曜日]
+    abbr_day_names: [日, 月, 火, 水, 木, 金, 土]
+
+
+    month_names: [~, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    abbr_month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+
+    order:
+      - :year
+      - :month
+      - :day
+
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      short: "%y/%m/%d %H:%M"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %Z"
+    am: "午前"
+    pm: "午後"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root  'users#index'
   resources :users do
     resources :schedules
+      match 'schedules', to: 'schedules#edit', via: [:patch]
   
   end
 end


### PR DESCRIPTION
## What
退勤の際に使用するupdateのルーツをeditに変更して、schedule.idがなくても更新できるように変更した。
schedules周りの、編集、削除機能を追加した。
上記の変更によりビューの調整、追加を行った。

## Why
当初、退勤処理をupdateアクションで行っていたが、そうなるとroutesに問題が生じたため。
解決法として、routes.rbにmatch 'schedules', to: 'schedules#edit', via: [:patch]を追加、そのため新たに PATCH  /users/:user_id/schedulesのルートパスをつくれたので、退勤処理をupdateからeditへ変更。
updateは個人の出退勤一覧ページより修正のために使うアクションとした。

